### PR TITLE
Feat preconfiguredlayers

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ The plugin can be loaded like this in an html-file:
 
           }
         ],
-        workspace: 'maplayers_wfs.fmw',
+        FMEWorkspace: 'maplayers_wfs.fmw',
         layers: [
             {
                 name: "sokvyx_intressepunkter_kff_ok_bibliotek",

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Geouttag
+
 Geouttag plugin for Origo using FME server Web Services. The user may draw a rectangle over the area to be exported, as well as choose a list of predefined layers/data sources to export.
 
 (<i>Is compatible with Origo v2.9</i>)
@@ -7,19 +8,21 @@ Layers in the map meant to be exportable via this plugin can be indicated via a 
 These layers share a configuration, including export formats, possible via wfs for instance, as well as an FME Flow workspace.
 
 #### Example usage of Geouttag as plugin
+
 The plugin can be loaded like this in an html-file:
+
 ```html
-  <head>
-	...
-	<link href="plugins/geouttag.css" rel="stylesheet">
-	</head>
-	...
-  <script src="js/origo.min.js"></script>
-  <script src="plugins/geouttag.min.js"></script>
-  <script type="text/javascript">
+<head>
+  ...
+  <link href="plugins/geouttag.css" rel="stylesheet" />
+</head>
+...
+<script src="js/origo.min.js"></script>
+<script src="plugins/geouttag.min.js"></script>
+<script type="text/javascript">
       const origo = Origo('index.json');
       origo.on('load', function(viewer) {
-      
+
       const geouttag = Geouttag({
         url: "URL to FME",
         filePath: "any path where user can get the export",
@@ -59,7 +62,7 @@ The plugin can be loaded like this in an html-file:
                 workspace: 'cycling_cad.fmw'
               },
               {
-                title: 'Shape',,
+                title: 'Shape',
                 workspace: 'cycling_shape.fmw'
               }
             ],
@@ -96,11 +99,22 @@ The plugin can be loaded like this in an html-file:
 
           }
         ],
-        workspace: 'maplayers_wfs.fmw'
-      } 
-		});
+        workspace: 'maplayers_wfs.fmw',
+        layers: [
+            {
+                name: "sokvyx_intressepunkter_kff_ok_bibliotek",
+                title: "Bibliotek",
+                workspace: "etuna"
+            },
+            {
+                name: "sokvyx_intressepunkter_utescen",
+                title: "Utescener",
+                workspace: "etuna"
+            }
+        ]
+      });
     viewer.addComponent(geouttag);
-                
+
     });
-        </script>
+</script>
 ```

--- a/src/geouttag.js
+++ b/src/geouttag.js
@@ -153,7 +153,7 @@ const Geouttag = function Geouttag(options = {}) {
     const availableFiletypes = selectedExport.filetypes || [];
     const fileTypeObj = availableFiletypes.find((filetype) => fileTypeName === filetype.title);
 
-    const FMEscript = fileTypeObj.workspace || maplayerExport.workspace;
+    const FMEscript = fileTypeObj.workspace || maplayerExport.FMEWorkspace;
     const fileType = fileTypeObj.outputFormat;
     const layerType = selectedExport.name || selectedExportName;
 

--- a/src/geouttag.js
+++ b/src/geouttag.js
@@ -57,6 +57,11 @@ const Geouttag = function Geouttag(options = {}) {
 
   loadSVGs();
 
+  function getMapLayersExist() {
+    const mapLayersExist = maplayerExport && maplayerExport.layers && (maplayerExport.layers.length > 0);
+    return mapLayersExist;
+  }
+
   /* State for the export button, if it should be enabled or disabled */
   function updateExportButtonState() {
     const exportBtnElement = document.getElementById(exportBtn.getId());
@@ -91,17 +96,17 @@ const Geouttag = function Geouttag(options = {}) {
     else if ((filetypeSelectElement.options.length === 0) && (filetypeSelectElement.disabled === false)) filetypeSelectElement.disabled = true;
   }
 
-  function getMaplayerOptions({ mapLayers, predefined }) {
-    const theLayers = mapLayers?.length > 0 ? mapLayers : predefined;
-    return theLayers.map((layer) => {
+  function getMaplayerOptions({ layers }) {
+    return layers.map((layer) => {
       const layerOptionElement = Origo.ui.Element({
         tagName: 'div',
         cls: 'option',
-        innerHTML: layer.get('title'),
+        innerHTML: layer['title'],
         attributes: {
           data: {
-            title: layer.get('title'),
-            name: layer.get('name')
+            title: layer['title'],
+            name: layer['name'],
+            workspace: layer['workspace']
           }
         }
       });
@@ -548,17 +553,19 @@ const Geouttag = function Geouttag(options = {}) {
       drawHandler.initializeMap(map);
 
       // projectionCode = map.getView().getProjection();
-      const mapLayers = Object.keys(maplayerExport).length ? viewer.getLayers().filter((layer) => layer.get('geouttag')) : [];
 
-      try {
-        const customSelectLayerOptions = getMaplayerOptions({
-          mapLayers
-        });
+      const mapLayers = maplayerExport.layers || []
 
-        customSelectOptionsDropdown.addComponents(customSelectLayerOptions);
-      } catch (e) {
-        console.warn('Could not create/attach mapLayerSelect now:', e);
-      }
+        try {
+          const customSelectLayerOptions = getMaplayerOptions({
+            layers: mapLayers
+          })
+          customSelectOptionsDropdown.addComponents(customSelectLayerOptions);
+        } catch (e) {
+          console.warn('Could not create/attach mapLayerSelect now:', e);
+        }
+
+
       if (predefinedExports) {
         predefinedExports.forEach((layer) => {
           if (layer.restricted) {
@@ -605,8 +612,10 @@ const Geouttag = function Geouttag(options = {}) {
           customSelectEl.disabled = true;
           customSelectEl.classList.add('disabled');
         } else {
-          customSelectEl.disabled = false;
-          customSelectEl.classList.remove('disabled');
+          if (getMapLayersExist()) {
+            customSelectEl.disabled = false;
+            customSelectEl.classList.remove('disabled');
+          }
           setFiletypes({ mapLayerOutputFormats: [] });
         }
         updateExportButtonState();
@@ -730,11 +739,12 @@ const Geouttag = function Geouttag(options = {}) {
       customSelectInput = Origo.ui.Element({
         tagName: 'input',
         attributes: {
-          type: 'text',
-          placeholder: 'Välj kartlager..'
+          type: 'text', // nedan för att oninit kommer före onadd. Kanske kan en funktion som returnerar mapLayersExists grund som bool fungera
+          placeholder: getMapLayersExist() ? 'Välj kartlager..' : 'Inga tillgängliga kartlager',
+          disabled: !(getMapLayersExist()),
           // allow typing to filter options
         },
-        cls: 'select-input custom-select-input text-small'
+        cls: `select-input custom-select-input text-small ${(getMapLayersExist()) ? '' : 'disabled'}`
       });
 
       customSelectOptionsDropdown = Origo.ui.Element({

--- a/src/geouttag.js
+++ b/src/geouttag.js
@@ -739,7 +739,7 @@ const Geouttag = function Geouttag(options = {}) {
       customSelectInput = Origo.ui.Element({
         tagName: 'input',
         attributes: {
-          type: 'text', // nedan för att oninit kommer före onadd. Kanske kan en funktion som returnerar mapLayersExists grund som bool fungera
+          type: 'text',
           placeholder: getMapLayersExist() ? 'Välj kartlager..' : 'Inga tillgängliga kartlager',
           disabled: !(getMapLayersExist()),
           // allow typing to filter options

--- a/src/geouttag.js
+++ b/src/geouttag.js
@@ -554,7 +554,7 @@ const Geouttag = function Geouttag(options = {}) {
 
       // projectionCode = map.getView().getProjection();
 
-      const mapLayers = maplayerExport.layers || []
+      const mapLayers = maplayerExport?.layers || []
 
         try {
           const customSelectLayerOptions = getMaplayerOptions({

--- a/src/geouttag.js
+++ b/src/geouttag.js
@@ -742,7 +742,6 @@ const Geouttag = function Geouttag(options = {}) {
           type: 'text',
           placeholder: getMapLayersExist() ? 'Välj kartlager..' : 'Inga tillgängliga kartlager',
           disabled: !(getMapLayersExist()),
-          // allow typing to filter options
         },
         cls: `select-input custom-select-input text-small ${(getMapLayersExist()) ? '' : 'disabled'}`
       });


### PR DESCRIPTION
Adds the ability to preconfigure the individual map server layers that should be exportable (they don't need to reside in the current map config). This is instead of them residing in the current map config and is to meet an internal wish.